### PR TITLE
Fixed out of bounds problem

### DIFF
--- a/data_conversion/geotiff2cm.py
+++ b/data_conversion/geotiff2cm.py
@@ -104,9 +104,9 @@ def process_geotiff(args):
                 x_arr = []
                 y_arr = []
                 z_arr = []
-                pbar = tqdm(total=(pic_bottom - pic_top + 2) * (pic_right - pic_left + 2))
-                for row in range(pic_top-1, pic_bottom+2):
-                    for col in range(pic_left-1, pic_right+2):
+                pbar = tqdm(total=(pic_bottom - pic_top) * (pic_right - pic_left))
+                for row in range(pic_top, pic_bottom):
+                    for col in range(pic_left, pic_right):
                         x, y = transformer.xy(row, col)
                         z = pic_data[row, col]
                         x_arr.append(x)


### PR DESCRIPTION
If you think the fix is stupid just reject it. I've provided the tif file I was getting the error with. Only used the -i to get the file. 
As far as I can tell its fixed it without any side effects, but I don't know the context of why the -1 and +2 was there in the first place.

[Kirchheim Height Data.zip](https://github.com/DerButschi/CMAutoEditor/files/10787081/Kirchheim.Height.Data.zip)
